### PR TITLE
Story - Support React versions <18.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,18 @@ prebuild-comp-site-react:
 		_prebuild-comp-site-react
 	cp ./src/comp-site/react/site/index.html ./build/comp-site/react/site-prebuild/index.html
 
+clean-prebuild-comp-site-react-sub18:
+	rm -rf ./build/comp-site/react/site-sub18-prebuild
+
+_prebuild-comp-site-react-sub18:
+	npx tsc -p ./src/comp-site/react/siteSub18/tsconfig.json
+
+prebuild-comp-site-react-sub18:
+	@$(MAKE) --no-print-directory \
+		clean-prebuild-comp-site-react-sub18 \
+		_prebuild-comp-site-react-sub18
+	cp ./src/comp-site/react/siteSub18/index.html ./build/comp-site/react/site-sub18-prebuild/index.html
+
 build-comp-site-react-dev:
 	npx env-cmd -e dev node ./build/comp-site/react/build/index.js
 
@@ -192,6 +204,7 @@ build-all:
 		build-api \
 		build-cli-rel \
 		prebuild-comp-site-react \
+		prebuild-comp-site-react-sub18 \
 		build-comp-site-react-build-build \
 		build-comp-site-react-build
 
@@ -215,7 +228,9 @@ populate-dist:
 	cp -r build/comp-site/react/build/ dist/npm/exhibitor/lib/comp-site/react/build
 
 	mkdir -p dist/npm/exhibitor/lib/comp-site/react/site-prebuild
-	cp -r build/comp-site/react/site-prebuild/ dist/npm/exhibitor/lib/comp-site/react/site-prebuild
+
+	mkdir -p dist/npm/exhibitor/lib/comp-site/react/site-sub18-prebuild
+	cp -r build/comp-site/react/site-sub18-prebuild/ dist/npm/exhibitor/lib/comp-site/react/site-sub18-prebuild/
 
 prepublish:
 	npm install

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ populate-dist:
 	cp -r build/comp-site/react/build/ dist/npm/exhibitor/lib/comp-site/react/build
 
 	mkdir -p dist/npm/exhibitor/lib/comp-site/react/site-prebuild
+	cp -r build/comp-site/react/site-prebuild/ dist/npm/exhibitor/lib/comp-site/react/site-prebuild/
 
 	mkdir -p dist/npm/exhibitor/lib/comp-site/react/site-sub18-prebuild
 	cp -r build/comp-site/react/site-sub18-prebuild/ dist/npm/exhibitor/lib/comp-site/react/site-sub18-prebuild/

--- a/Makefile
+++ b/Makefile
@@ -228,10 +228,10 @@ populate-dist:
 	cp -r build/comp-site/react/build/ dist/npm/exhibitor/lib/comp-site/react/build
 
 	mkdir -p dist/npm/exhibitor/lib/comp-site/react/site-prebuild
-	cp -r build/comp-site/react/site-prebuild/ dist/npm/exhibitor/lib/comp-site/react/site-prebuild/
+	cp -r build/comp-site/react/site-prebuild/ dist/npm/exhibitor/lib/comp-site/react/site-prebuild
 
 	mkdir -p dist/npm/exhibitor/lib/comp-site/react/site-sub18-prebuild
-	cp -r build/comp-site/react/site-sub18-prebuild/ dist/npm/exhibitor/lib/comp-site/react/site-sub18-prebuild/
+	cp -r build/comp-site/react/site-sub18-prebuild/ dist/npm/exhibitor/lib/comp-site/react/site-sub18-prebuild
 
 prepublish:
 	npm install

--- a/dist/npm/exhibitor/package.json
+++ b/dist/npm/exhibitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exhibitor",
-  "version": "2.0.9",
+  "version": "2.0.10-beta.4",
   "description": "Snappy and delightful React component workshop",
   "main": "./lib/api/api/index.js",
   "types": "./lib/api/api/index.d.ts",

--- a/src/comp-site/react/build/build.ts
+++ b/src/comp-site/react/build/build.ts
@@ -19,13 +19,16 @@ const getPaths = (options: BuildOptions) => {
   }
 
   const COMP_SITE_REACT_SITE_PREBUILD_OUTDIR = './build/comp-site/react/site-prebuild'
+
+  const compSiteSuffix = options.reactMajorVersion < 18 ? '-sub18' : ''
+  const compSiteSuffix2 = options.reactMajorVersion < 18 ? 'sub18' : ''
   return {
     entrypoint: isDev
       ? `${COMP_SITE_REACT_SITE_PREBUILD_OUTDIR}/comp-site/react/site/main.js`
-      : `./node_modules/${NPM_PACKAGE_NAME}/lib/comp-site/react/site-prebuild/comp-site/react/site/main.js`,
+      : `./node_modules/${NPM_PACKAGE_NAME}/lib/comp-site/react/site${compSiteSuffix}-prebuild/comp-site/react/site${compSiteSuffix2}/main.js`,
     htmlFilePath: isDev
       ? `${COMP_SITE_REACT_SITE_PREBUILD_OUTDIR}/index.html`
-      : `./node_modules/${NPM_PACKAGE_NAME}/lib/comp-site/react/site-prebuild/index.html`,
+      : `./node_modules/${NPM_PACKAGE_NAME}/lib/comp-site/react/site${compSiteSuffix}-prebuild/index.html`,
   }
 }
 

--- a/src/comp-site/react/build/types.ts
+++ b/src/comp-site/react/build/types.ts
@@ -6,6 +6,7 @@ export type BuildOptions = {
   gzip: boolean
   verbose: boolean
   skipPrebuild: boolean
+  reactMajorVersion: number
 }
 
 export type BuildOutput = {

--- a/src/comp-site/react/siteSub18/.eslintrc.json
+++ b/src/comp-site/react/siteSub18/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 13,
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  },
+  "env": {
+    "browser": true
+  },
+  "rules": {
+    "no-restricted-globals": "warn"
+  }
+}

--- a/src/comp-site/react/siteSub18/README.md
+++ b/src/comp-site/react/siteSub18/README.md
@@ -1,0 +1,1 @@
+This is the React component site for versions sub-v18. React v18 introduced breaking changes. This is a small React app that is designed to be inside an iframe, listen for changes to the selected exhibit variant path, and display the corresponding variant for a particular variant path.

--- a/src/comp-site/react/siteSub18/index.d.ts
+++ b/src/comp-site/react/siteSub18/index.d.ts
@@ -1,0 +1,15 @@
+/**
+ * This file defines the globally variables exposed
+ * by the exhibitor JS API functions like `exhibit()`.
+ */
+import { ComponentExhibits, ExhibitNodes, PathTree } from '../../../api/exhibit/types'
+
+declare interface ComponentExhibitGlobals {
+  default: ComponentExhibits
+  nodes: ExhibitNodes
+  pathTree: PathTree
+}
+
+declare global {
+  const exh: ComponentExhibitGlobals
+}

--- a/src/comp-site/react/siteSub18/index.html
+++ b/src/comp-site/react/siteSub18/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <script defer="" src="/comp-site/index.js"></script>
+    <script async="" src="/index.exh.js"></script>
+    <link rel="stylesheet" href="/index.exh.css">
+    <style>
+      body { margin: 0 }
+      html { display: flex; justify-content: center; align-items: center; width: 100%; height: 100% }
+    </style>
+  </head>
+  <body>
+    <div id="exh-root"></div>
+  </body>
+</html>

--- a/src/comp-site/react/siteSub18/main.tsx
+++ b/src/comp-site/react/siteSub18/main.tsx
@@ -1,0 +1,41 @@
+/* eslint react/jsx-filename-extension: 0 */
+import React, { useEffect, useState } from 'react'
+import { render } from 'react-dom'
+import { VariantExhibitNode } from '../../../api/exhibit/types'
+import { getSelectedVariantNodePath, waitUntilComponentExhibitsAreLoaded } from '../../../common/exhibit'
+import { attachEventLoggingToProps } from '../../common'
+
+const container = document.getElementById('exh-root')
+
+const App = () => {
+  const [ready, setReady] = useState(false)
+  const [selectedVariantPath, setSelectedVariantPath] = useState(getSelectedVariantNodePath())
+
+  // Add a listener for the custom event for when a selected variant changes.
+  useEffect(() => {
+    const handler = () => setSelectedVariantPath(getSelectedVariantNodePath())
+    window.addEventListener('selected-variant-change', handler)
+    return () => {
+      window.removeEventListener('selected-variant-change', handler)
+    }
+  }, [])
+
+  if (!ready) {
+    waitUntilComponentExhibitsAreLoaded().then(() => {
+      setSelectedVariantPath(getSelectedVariantNodePath())
+      setReady(true)
+    })
+    return <div className="component-exhibit not-ready">Loading...</div>
+  }
+
+  if (selectedVariantPath == null)
+    return <div className="component-exhibit not-found">NOT SELECTED</div>
+
+  const selectedVariantNode = exh.nodes[selectedVariantPath] as VariantExhibitNode
+
+  const variantProps = attachEventLoggingToProps(selectedVariantNode)
+
+  return selectedVariantNode.exhibit.renderFn(variantProps)
+}
+
+render(<App />, container)

--- a/src/comp-site/react/siteSub18/tsconfig.json
+++ b/src/comp-site/react/siteSub18/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "include": [
+    "./**/*"
+  ],
+  "compilerOptions": {
+    "target": "es6",
+    "moduleResolution": "node",
+    "module": "ES6",
+    "allowJs": false,
+    "strictNullChecks": false,
+		"strict": true,
+		"isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "declaration": false,
+    "sourceMap": false,
+    "noEmit": false,
+    "skipLibCheck": true,
+    "outDir": "../../../../build/comp-site/react/site-sub18-prebuild",
+    "jsx": "react"
+  }
+}


### PR DESCRIPTION
This PR adds a Component Site for React versions earlier than v18, and some logic in the CLI's `start` command to switch between the >=v18 and <v18 React component sites depending on the version of the resolved React package that the user has installed.