### PR TITLE
Story - Support Angular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 /dist/npm/exhibitor/node_modules
 /dist/npm/exhibitor/package-lock.json
 /build-test
+
+# TODO: Delete later.
+/src/comp-site/angular/node_modules
+/src/comp-site/angular/.angular


### PR DESCRIPTION
So far, this PR creates an Angular Component Site PoC, without rootStyles or component props support. It can be ran by `npm run build-comp-site-angular-build && npm run watch-comp-site-angular-dev`.

The `index.exh.ts` file is included as usual just like it is for the React Component Site. This appeared to work as expected.

It has identified a number of aspects about the Component Site codebase that are problematic, most of which stem from the fact that it is tailored towards React and React-like frameworks.

Angular is a very heavy and fat framework that is highly controlled - very different from React.

With React:
* Can just be built by esbuild into a bunch HTML, CSS, and JS.
* Then served by Site Server.
* Therefore easy integration with rest of Exhibitor, e.g. Intercom

With Angular:
* Angular apps require a very precisely set up directory with framework config files.
* Requires the Angular CLI to serve all of the files.
* Therefore difficult to integrate with Intercom.